### PR TITLE
Switch from dill to cloudpickle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import sys
 
 setup(
     name='nodebook',
-    version='0.2.1',
+    version='0.3.0',
     author='Kevin Zielnicki',
     author_email='kzielnicki@stitchfix.com',
-    license='Stitch Fix 2017',
+    license='Stitch Fix 2018',
     description='Nodebook Jupyter Extension',
     packages=find_packages(),
     long_description='Nodebook Jupyter Extension',
@@ -17,7 +17,7 @@ setup(
         'ipython',
         'jupyter',
         'click',
-        'dill',
+        'cloudpickle',
         'msgpack-python',
         'pandas',
         'pytest-runner',

--- a/tests/test_pickledict.py
+++ b/tests/test_pickledict.py
@@ -40,6 +40,15 @@ class TestPickleDict(object):
         mydict['test_func'] = add
         assert mydict['test_func'](3,5) == 8
 
+    def test_closure(self, mydict):
+        df = pd.DataFrame({'a': [0, 1, 2], 'b': ['foo', 'bar', 'baz']})
+        def foo():
+            return df
+        def bar():
+            return foo()
+        mydict['test_closure'] = bar
+        assert mydict['test_closure']().equals(df)
+
     def test_immutability(self, mydict):
         l = [1, 2, 3]
         mydict['test_mut'] = l

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36
+
+[testenv]
+commands = pytest
+deps =
+    pytest


### PR DESCRIPTION
Dill would fail to serialize dataframes in closures, cloudpickle appears to handle this better, and also seems to have more community traction than dill, so I'm switching to cloudpickle.

Fixes #11