### PR TITLE
handle ValueError

### DIFF
--- a/nodebook/ipython/nodebookext.py
+++ b/nodebook/ipython/nodebookext.py
@@ -67,7 +67,11 @@ def execute_cell(line, cell):
     ipython magic for executing nodebook cell, expects cell id and parent id inline, followed by code
     """
     assert NODEBOOK_STATE['nodebook'] is not None, "Nodebook not initialized, please use %nodebook {nodebook_name}"
-    cell_id, parent_id = line.lstrip().split(' ')
+    try:
+        cell_id, parent_id = line.lstrip().split(' ')
+    except ValueError:
+        cell_id = line.lstrip()
+        parent_id = None
 
     # make sure cell exists and is in the right position
     NODEBOOK_STATE['nodebook'].insert_node_after(cell_id, parent_id)

--- a/nodebook/pickledict.py
+++ b/nodebook/pickledict.py
@@ -26,7 +26,7 @@ try:
     from UserDict import DictMixin
 except ImportError:
     # see https://github.com/flask-restful/flask-restful/pull/231/files
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
 
 PANDAS_CODE = 1
 CLOUDPICKLE_CODE = 2


### PR DESCRIPTION
Hi,

This PR fixes the following exception:

```python
ValueError                                Traceback (most recent call last)
<ipython-input-7-705f095156ba> in <module>
----> 1 get_ipython().run_cell_magic('execute_cell', ' EB910D7B09F2443081D464E1B36C9392', 'x = 4\n')

/usr/local/lib/python3.8/dist-packages/IPython/core/interactiveshell.py in run_cell_magic(self, magic_name, line, cell)
   2401             with self.builtin_trap:
   2402                 args = (magic_arg_s, cell)
-> 2403                 result = fn(*args, **kwargs)
   2404             return result
   2405 

~/git/nodebook/nodebook/ipython/nodebookext.py in execute_cell(line, cell)
     70     print(line.lstrip().split(' '))
     71     assert NODEBOOK_STATE['nodebook'] is not None, "Nodebook not initialized, please use %nodebook {nodebook_name}"
---> 72     cell_id, parent_id = line.lstrip().split(' ')
     73 
     74     # make sure cell exists and is in the right position

ValueError: not enough values to unpack (expected 2, got 1)
```

This problem appears to have been caused by ipython `rstrip`ing the `%%execute_cell` line magic - if the trailing space were there, `parent_id` would be ''. Note this problem only occurs with the first cell in the notebook, as it's the only cell without a parent.